### PR TITLE
Blueprint Notification Service Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ restarting Home Assistant, add and configure the integration through the native 
 
 ### Blueprint Parameters
 
-
-| Parameter                   | Description                                                                                                                                                                                                                                                                                                                                     |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Home Assistant Host**     | The address of your Home Assistant instance. Required for sending the printer camera image to the Obico ML server. Ensure to include your Home Assistant port. This address is also used for notification images. If you wish to view failure images on notifications outside your local network, provide a publicly accessible link here. |
-| **Obico ML API Host**       | The URL of the Obico ML Server. The default port number is `3333`. If you installed the ML server via the Home Assistant Addon, the IP address should match your Home Assistant address.                                                                                                                                                        |
-| **Obico ML API Auth Token** | The authentication token for the Obico ML Server. The default value is `obico_api_secret` and can be configured through the addon settings or the docker container create command.                                                                                                                                                              |
-| **Notification Settings**   | - **Critical Notification:** Generates an audible alert even when your device is in silent mode.<br/>- **Standard Notification:** Sends a traditional notification respecting your device's audio settings.<br/>- **None:** No notifications are sent in case of a failure.                                                                     |
+| Parameter | Description
+| ---- | ----- |
+| **Home Assistant Host** | The address of your Home Assistant instance. Required for sending the printer camera image to the Obico ML server. Ensure to include your Home Assistant port. This address is also used for notification images. If you wish to view failure images on notifications outside your local network, provide a publicly accessible link here.
+| **Obico ML API Host** | The URL of the Obico ML Server. The default port number is `3333`. If you installed the ML server via the Home Assistant Addon, the IP address should match your Home Assistant address.
+| **Obico ML API Auth Token** | The authentication token for the Obico ML Server. The default value is `obico_api_secret` and can be configured through the addon settings or the docker container create command.
+| **Notification Settings** | - **Critical Notification:** Generates an audible alert even when your device is in silent mode.<br/>- **Standard Notification:** Sends a traditional notification respecting your device's audio settings.<br/>- **None:** No notifications are sent in case of a failure.
+| **Notification Service** | Allows you to select a custom notification service to use when sending notifications. Default: `notify.notify`.
 
 
 ## Credits

--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -35,6 +35,10 @@ blueprint:
               value: standard
             - label: None
               value: none
+    notification_service:
+      name: Notification Service
+      description: Notification service used to sent messages
+      default: notify.notify
     failure_action:
       name: On Failure Action
       description: What to do after detecting a failure
@@ -112,6 +116,7 @@ variables:
   PRINTER_CAMERA_IMG_VAR: !input printer_camera_image
   FAILURE_ACTION_VAR: !input failure_action
   NOTIFICATION_SETTINGS_VAR: !input notification_settings
+  NOTIFICATION_SERVICE_VAR: !input notification_service
 mode: single
 max_exceeded: silent
 trigger:
@@ -403,7 +408,7 @@ action:
                   - condition: template
                     value_template: "{{ NOTIFICATION_SETTINGS_VAR == 'critical' }}"
                 sequence:
-                  - service: notify.notify
+                  - service: "{{ NOTIFICATION_SERVICE_VAR }}"
                     data:
                       title: "Bambu Lab P1 - Spaghetti Detected"
                       message: "Confidence: {{ (states('number.bambu_lab_p1_spaghetti_detection_normalized_p') | float * 100) | int }}%"
@@ -426,7 +431,7 @@ action:
                   - condition: template
                     value_template: "{{ NOTIFICATION_SETTINGS_VAR == 'standard' }}"
                 sequence:
-                  - service: notify.notify
+                  - service: "{{ NOTIFICATION_SERVICE_VAR }}"
                     data:
                       title: "Bambu Lab P1 - Spaghetti Detected"
                       message: "Confidence: {{ (states('number.bambu_lab_p1_spaghetti_detection_normalized_p') | float * 100) | int }}%"

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,2 +1,5 @@
+### V1.0.1
+- Add notification service input to blueprint
+
 ### V1.0.0
 - Initial release


### PR DESCRIPTION
Firstly - Awesome job with this Integration, tested and it works a treat!

This PR adds a new input to the Automation blueprint allowing the definition of a custom notification service.

Providing this as a selector does not seem to exist in the blueprint framework, so its just a text input field with the default defined. 

Happy for thoughts/better way of including this - I personally use different notifications services for family/admin notifications to wanted to include this flexibility.

I also reformatted the table in the README doc, this should (in theory) render correctly without the padding.

I have raised this PR against main as there is no develop branch yet 👀 