### PR TITLE
Add input field for notification service and docker compose for obico

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ To install Obico ML server as a Home Assistant Add-on you have 2 options:
 
        docker start ha_bambu_lab_p1_spaghetti_detection
 
+### Install Obico ML Server as a Standalone Docker Container using docker compose
+
+1. Download the docker-compose.yaml from the repository
+
+2. Edit the environment variables section in the docker compose yaml:
+
+      ```
+      environment:
+        - ML_API_TOKEN=obico_api_secret
+        - TZ=Europe/Ljubljana
+      ```
+
+3. Run the command:
+
+       docker compose up -d
+
 ## 2. Install Home Assistant Integration
 
 ### HACS

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ To install Obico ML server as a Home Assistant Add-on you have 2 options:
 
        https://github.com/nberktumer/ha-bambu-lab-p1-spaghetti-detection
 
-### Install Obico ML Server as a Standalone Docker Container
+### Install Obico ML Server standalone using one of the following two options
+
+#### Install Obico ML Server as a Standalone Docker Container
 
 1. Create docker container using the following command:
 
@@ -78,7 +80,7 @@ To install Obico ML server as a Home Assistant Add-on you have 2 options:
 
        docker start ha_bambu_lab_p1_spaghetti_detection
 
-### Install Obico ML Server as a Standalone Docker Container using docker compose
+#### Install Obico ML Server as a Standalone Docker Container using docker compose
 
 1. Download the docker-compose.yaml from the repository
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ restarting Home Assistant, add and configure the integration through the native 
 | **Obico ML API Host**       | The URL of the Obico ML Server. The default port number is `3333`. If you installed the ML server via the Home Assistant Addon, the IP address should match your Home Assistant address.                                                                                                                                                        |
 | **Obico ML API Auth Token** | The authentication token for the Obico ML Server. The default value is `obico_api_secret` and can be configured through the addon settings or the docker container create command.                                                                                                                                                              |
 | **Notification Settings**   | - **Critical Notification:** Generates an audible alert even when your device is in silent mode.<br/>- **Standard Notification:** Sends a traditional notification respecting your device's audio settings.<br/>- **None:** No notifications are sent in case of a failure.                                                                     |
+| **Notification Service**   | The notification service of your choice for selecting a single device or a group of devices, instead of alerting all mobile devices registered in home assistant. The default is `notify.notify`, which notifies all devices.                                                                     |
 
 
 ## Credits

--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -47,7 +47,14 @@ blueprint:
               value: pause
             - label: Stop
               value: stop
-
+    notification_service:
+      name: Mobile devices notification service
+      description: >-
+        The notification service for mobile devices (eg. notify.mobile_app_<your_device_id_here>).
+        You can provide both a notify group or a single notify device here.
+      default: notify.notify
+      selector:
+        text:
     printer_print_status_sensor:
       name: Printer Print Status Sensor
       description: Bambu Lab printer print status sensor
@@ -403,7 +410,7 @@ action:
                   - condition: template
                     value_template: "{{ NOTIFICATION_SETTINGS_VAR == 'critical' }}"
                 sequence:
-                  - service: notify.notify
+                  - service: !input notification_service
                     data:
                       title: "Bambu Lab P1 - Spaghetti Detected"
                       message: "Confidence: {{ (states('number.bambu_lab_p1_spaghetti_detection_normalized_p') | float * 100) | int }}%"
@@ -426,7 +433,7 @@ action:
                   - condition: template
                     value_template: "{{ NOTIFICATION_SETTINGS_VAR == 'standard' }}"
                 sequence:
-                  - service: notify.notify
+                  - service: !input notification_service
                     data:
                       title: "Bambu Lab P1 - Spaghetti Detected"
                       message: "Confidence: {{ (states('number.bambu_lab_p1_spaghetti_detection_normalized_p') | float * 100) | int }}%"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+---
+version: "3"
+services:
+  ha_bambu_lab_p1_spaghetti_detection:
+    image: nberk/ha_bambu_lab_p1_spaghetti_detection_standalone:latest
+    container_name: ha_bambu_lab_p1_spaghetti_detection
+    restart: unless-stopped
+    ports:
+      - 3333:3333/tcp
+    environment:
+      - ML_API_TOKEN=obico_api_secret
+      - TZ=Europe/London


### PR DESCRIPTION
Wanted to add an option to not alert all devices, as not all users in my HA use the 3D printer. So I added an input field in the blueprint, where you can specify the notification service of a single device or group of devices, with a default of notifying all devices.
I also added a docker compose yaml for spinning up the obico container, instead of using the docker create/run command.

