### PR TITLE
Reset calculated values and only turn the chamber light on, if it was previously off

### DIFF
--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -168,6 +168,11 @@ action:
                 - number.bambu_lab_p1_spaghetti_detection_ewm_mean
                 - number.bambu_lab_p1_spaghetti_detection_rolling_mean_short
           - if:
+            - condition: and
+              conditions:
+              - condition: state
+                entity_id: !input printer_chamber_light
+                state: 'off'
               - condition: template
                 value_template: !input auto_turn_on_light
             then:
@@ -233,6 +238,11 @@ action:
             then:
               - stop: ""
           - if:
+            - condition: and
+              conditions:
+              - condition: state
+                entity_id: !input printer_chamber_light
+                state: 'off'
               - condition: template
                 value_template: !input auto_turn_on_light
             then:
@@ -444,7 +454,18 @@ action:
                             title: Resume Printing
                           - action: BAMBU_LAB_STOP_PRINTING
                             title: Stop Printing
-
+          - service: number.set_value
+            data:
+              value: 0
+            target:
+              entity_id:
+              - number.bambu_lab_p1_spaghetti_detection_current_frame_number
+              - number.bambu_lab_p1_spaghetti_detection_ewm_mean
+              - number.bambu_lab_p1_spaghetti_detection_rolling_mean_short
+              - number.bambu_lab_p1_spaghetti_detection_rolling_mean_long
+              - number.bambu_lab_p1_spaghetti_detection_normalized_p
+              - number.bambu_lab_p1_spaghetti_detection_adjusted_ewm_mean
+              - number.bambu_lab_p1_spaghetti_detection_p_sum
           - service: datetime.set_value
             data:
               datetime: >-


### PR DESCRIPTION
This change will improve 2 things

- Positive detection after a detection happend (fixes #17)
- The automation is hammering the MQTT bus by sending repeated requests to turn on the light, even though it is already on (fixes #18)