### PR TITLE
Updated blueprint and Readme to account for new Bambu Labs Camera breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ restarting Home Assistant, add and configure the integration through the native 
 
 ![Configure the automation](docs/images/blueprint_installation.png)
 
+3. **Important** If you are on version 2.0.22 or older, make sure that the value for "Printer Frame Refresh" is the image. For versions 2.0.23 and newer, this value should be a sensor, like the current layer of your printer.
+
 ### Blueprint Parameters
 
 

--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -167,6 +167,10 @@ action:
                 - number.bambu_lab_p1_spaghetti_detection_current_frame_number
                 - number.bambu_lab_p1_spaghetti_detection_ewm_mean
                 - number.bambu_lab_p1_spaghetti_detection_rolling_mean_short
+                - number.bambu_lab_p1_spaghetti_detection_rolling_mean_long
+                - number.bambu_lab_p1_spaghetti_detection_normalized_p
+                - number.bambu_lab_p1_spaghetti_detection_adjusted_ewm_mean
+                - number.bambu_lab_p1_spaghetti_detection_p_sum
           - if:
             - condition: and
               conditions:
@@ -459,13 +463,13 @@ action:
               value: 0
             target:
               entity_id:
-              - number.bambu_lab_p1_spaghetti_detection_current_frame_number
-              - number.bambu_lab_p1_spaghetti_detection_ewm_mean
-              - number.bambu_lab_p1_spaghetti_detection_rolling_mean_short
-              - number.bambu_lab_p1_spaghetti_detection_rolling_mean_long
-              - number.bambu_lab_p1_spaghetti_detection_normalized_p
-              - number.bambu_lab_p1_spaghetti_detection_adjusted_ewm_mean
-              - number.bambu_lab_p1_spaghetti_detection_p_sum
+                - number.bambu_lab_p1_spaghetti_detection_current_frame_number
+                - number.bambu_lab_p1_spaghetti_detection_ewm_mean
+                - number.bambu_lab_p1_spaghetti_detection_rolling_mean_short
+                - number.bambu_lab_p1_spaghetti_detection_rolling_mean_long
+                - number.bambu_lab_p1_spaghetti_detection_normalized_p
+                - number.bambu_lab_p1_spaghetti_detection_adjusted_ewm_mean
+                - number.bambu_lab_p1_spaghetti_detection_p_sum
           - service: datetime.set_value
             data:
               datetime: >-

--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -82,7 +82,19 @@ blueprint:
         entity:
           filter:
             - integration: bambu_lab
-              domain: image
+              domain: 
+                - image
+                - camera
+    printer_frame:
+      name: Printer Frame Refresh
+      description: When the photo frame should be captured
+      selector:
+        entity:
+          filter:
+            - integration: bambu_lab
+              domain: 
+                - sensor
+                - image
     printer_pause_button:
       name: Printer Pause Button Entity
       description: Bambu Lab printer pause button entity
@@ -152,7 +164,7 @@ trigger:
   - platform: state
     id: BAMBU_LAB_CAMERA_FRAME_CHANGE
     entity_id:
-      - !input printer_camera_image
+      - !input printer_frame
 condition: [ ]
 action:
   - choose:
@@ -186,15 +198,20 @@ action:
                 target:
                   entity_id:
                     - !input printer_chamber_light
+
+          # Used to reload config in case camera freezes
           - if:
-              - condition: template
-                value_template: "{{ as_timestamp(now()) - as_timestamp(states(PRINTER_CAMERA_IMG_VAR)) >= 30 }}"
+              - condition: and
+                conditions: 
+                - condition: template
+                  value_template: "{{ as_timestamp(now()) - as_timestamp(states(PRINTER_CAMERA_IMG_VAR)) >= 30 }}"
+                - condition: template
+                  value_template: "{{ states[PRINTER_CAMERA_IMG_VAR].domain == 'image' }}" # For versions <= 2.0.22
             then:
               - service: homeassistant.reload_config_entry
                 data: { }
                 target:
                   entity_id: !input printer_camera_image
-
       # Notification actions
       - conditions:
           - condition: trigger
@@ -478,5 +495,3 @@ action:
                 {{ now() }}
             target:
               entity_id: datetime.bambu_lab_p1_spaghetti_detection_last_notify_time
-
-


### PR DESCRIPTION
I was able to modify the blueprint to account for the breaking change in 2.0.23+. Because the image entity is now a camera entity, the refresh cadence was delayed to ~5 minute intervals, which was too slow to send updates to the Obico server. As a result, I built another blueprint variable "Printer Frame Refresh" that can be used to link when the printer should send an image to the Obico server. During testing, I have it working using the "Current layer" sensor. This effectively sends a photo to the server every time a new layer is made.

<img width="1099" alt="Screenshot 2024-10-28 at 3 46 55 PM" src="https://github.com/user-attachments/assets/aab6ebc0-8602-49c9-9c45-2a5f15bae6f4">

I couldn't find a sensor or state change in the Bambu lab integration that is quicker than that. For users who have the old integration ( <= 2.0.22 ), they can just replicate the image entity into this "Printer Frame Refresh" blueprint variable. However, I couldn't downgrade to test this, although logically this should work completely fine. This is explained in the Readme.

Finally, I also modified the reload_config_entry function to _only_ apply to the older integration ( <= 2.0.22 ) as with the current frame refresh at the layer level, this could theoretically be over 30 seconds, causing a false positive refresh.