### PR TITLE
Utilize detection frequency variable instead of 1 second

### DIFF
--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -161,7 +161,7 @@ trigger:
   # Detection trigger
   - trigger: time_pattern
     id: BAMBU_LAB_DETECTION_TRIGGER
-    seconds: /1
+    seconds: !input detection_frequency
 condition: [ ]
 action:
   - choose:


### PR DESCRIPTION
Fixes frequency of detection to utilize the input variable instead of a hardcoded "every second" scan. Fixes issues #28 