### PR TITLE
Change detection frequency to selector instead of number

### DIFF
--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -20,11 +20,20 @@ blueprint:
       description: The detection algorithm will run in every defined seconds
       default: 5
       selector:
-        number:
-          min: 1
-          max: 60
-          mode: box
-          unit_of_measurement: seconds
+        select:
+          options:
+            - label: Every second
+              value: "/1"
+            - label: Every 5 seconds
+              value: "/5"
+            - label: Every 10 seconds
+              value: "/10"
+            - label: Every 30 seconds
+              value: "/30"
+            - label: Every 60 seconds
+              value: "/60"
+          multiple: false
+          mode: dropdown
     auto_turn_on_light:
       name: Automatically Turn On Printer Lights
       description: Turns on printer lights before spaghetti detection operation


### PR DESCRIPTION
Needed to change selector from number to select to allow "every X seconds". No way to convert a number to a "/number" in Home Assistant.

I coded options for 1, 5, 10, 30, and 60 seconds which should account for a variety of options. Tested and working.

This is an updated fix for #28 as that didn't allow every X second and was running every "1:XX" seconds.