### PR TITLE
Fix warning in logs after #39

### DIFF
--- a/blueprints/spaghetti_detection.yaml
+++ b/blueprints/spaghetti_detection.yaml
@@ -255,7 +255,7 @@ action:
               - stop: ""
           - if:
               - condition: template
-                value_template: "{{ now().second % DETECTION_FREQUENCY_VAR > 0 }}"
+                value_template: "{{ now().second % DETECTION_FREQUENCY_VAR | replace(''/'', '''') | int > 0 }}"
             then:
               - stop: ""
           - if:


### PR DESCRIPTION
After #39 was introduced, there is a condition https://github.com/nberktumer/ha-bambu-lab-p1-spaghetti-detection/blob/main/blueprints/spaghetti_detection.yaml#L258 that is invalid

This is spammed in logs:
2025-03-15 23:31:15.434 WARNING (MainThread) [homeassistant.helpers.script] Error in 'if[0]' evaluation: In 'template' condition: TypeError: unsupported operand type(s) for %: 'int' and 'NodeStrClass'

Basically /x is not a valid number, did a simple conversation.