### PR TITLE
Create device to group entities

### DIFF
--- a/custom_components/bambu_lab_p1_spaghetti_detection/__init__.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/__init__.py
@@ -6,8 +6,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 
-DOMAIN = "bambu_lab_p1_spaghetti_detection"
-BRAND = "Bambu Lab P1 - Spaghetti Detection"
+from .const import (
+    DOMAIN,
+    BRAND,
+)
 
 LOGGER = logging.getLogger(__package__)
 

--- a/custom_components/bambu_lab_p1_spaghetti_detection/config_flow.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/config_flow.py
@@ -6,7 +6,9 @@ from typing import Any
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 
-from custom_components.bambu_lab_p1_spaghetti_detection import DOMAIN
+from .const import (
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/bambu_lab_p1_spaghetti_detection/const.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/const.py
@@ -1,5 +1,5 @@
 #DOMAIN
-DOMAIN = "ha_bambu_lab_p1_spaghetti_detection"
+DOMAIN = "bambu_lab_p1_spaghetti_detection"
 # Device
 BRAND = "Bambu Lab P1 - Spaghetti Detection"
 DEVICE_NAME = "HA Spaghetti Detection"

--- a/custom_components/bambu_lab_p1_spaghetti_detection/const.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/const.py
@@ -1,0 +1,8 @@
+#DOMAIN
+DOMAIN = "ha_bambu_lab_p1_spaghetti_detection"
+# Device
+BRAND = "Bambu Lab P1 - Spaghetti Detection"
+DEVICE_NAME = "HA Spaghetti Detection"
+DEVICE_MANUFACTURER = "Custom"
+DEVICE_MODEL = "HA Spaghetti Detection"
+DEVICE_ENTRY_TYPE = "service"

--- a/custom_components/bambu_lab_p1_spaghetti_detection/datetime.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/datetime.py
@@ -2,6 +2,14 @@ from datetime import datetime, timezone
 
 from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDescription
 
+from .const import (
+    DOMAIN,
+    DEVICE_NAME,
+    DEVICE_MANUFACTURER,
+    DEVICE_MODEL,
+    DEVICE_ENTRY_TYPE,
+)
+
 DATETIME_TYPES: tuple[DateTimeEntityDescription, ...] = (
     DateTimeEntityDescription(
         key="last_notify_time",
@@ -12,22 +20,23 @@ DATETIME_TYPES: tuple[DateTimeEntityDescription, ...] = (
 
 async def async_setup_entry(hass, entry, async_add_entities):
     entities = [
-        BambuLabP1SpaghettiDetectionDateTimeEntity(entity_description) for entity_description in DATETIME_TYPES
+        BambuLabP1SpaghettiDetectionDateTimeEntity(entry.entry_id, entity_description)
+        for entity_description in DATETIME_TYPES
     ]
-
     async_add_entities(entities)
 
 
 class BambuLabP1SpaghettiDetectionDateTimeEntity(DateTimeEntity):
-    def __init__(self, entity_description):
+    def __init__(self, entry_id, entity_description):
         self.entity_description = entity_description
+        self._entry_id = entry_id  # ✅ Set the entry_id
 
-        self.entity_id = "number.bambu_lab_p1_spaghetti_detection_%s" % entity_description.key
-        self._attr_unique_id = "number.bambu_lab_p1_spaghetti_detection_%s" % entity_description.key
+        self.entity_id = f"datetime.bambu_lab_p1_spaghetti_detection_{entity_description.key}"
+        self._attr_unique_id = f"datetime.bambu_lab_p1_spaghetti_detection_{entity_description.key}"
         self._attr_native_value = datetime.fromtimestamp(0, timezone.utc)
 
     async def async_set_value(self, value: datetime) -> None:
-        """Set the value of the number entity."""
+        """Set the value of the datetime entity."""
         self._attr_native_value = value
         self.async_write_ha_state()
 
@@ -35,3 +44,13 @@ class BambuLabP1SpaghettiDetectionDateTimeEntity(DateTimeEntity):
         """Set the value of the number entity."""
         self._attr_native_value = value
         self.async_write_ha_state()
+   
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": DEVICE_NAME,
+            "manufacturer": DEVICE_MANUFACTURER,
+            "model": DEVICE_MODEL,
+            "entry_type": DEVICE_ENTRY_TYPE,
+        }

--- a/custom_components/bambu_lab_p1_spaghetti_detection/number.py
+++ b/custom_components/bambu_lab_p1_spaghetti_detection/number.py
@@ -1,5 +1,13 @@
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 
+from .const import (
+    DOMAIN,
+    DEVICE_NAME,
+    DEVICE_MANUFACTURER,
+    DEVICE_MODEL,
+    DEVICE_ENTRY_TYPE,
+)
+
 NUMBER_TYPES: tuple[NumberEntityDescription, ...] = (
     NumberEntityDescription(
         key="current_frame_number",
@@ -88,22 +96,32 @@ NUMBER_TYPES: tuple[NumberEntityDescription, ...] = (
 
 async def async_setup_entry(hass, entry, async_add_entities):
     entities = [
-        BambuLabP1SpaghettiDetectionNumberEntity(entity_description) for entity_description in NUMBER_TYPES
+        BambuLabP1SpaghettiDetectionNumberEntity(entry.entry_id, entity_description)
+        for entity_description in NUMBER_TYPES
     ]
-
     async_add_entities(entities)
 
 
 class BambuLabP1SpaghettiDetectionNumberEntity(NumberEntity):
-    def __init__(self, entity_description):
+    def __init__(self, entry_id, entity_description):
         self.entity_description = entity_description
+        self._entry_id = entry_id  # 
 
-        self.entity_id = "number.bambu_lab_p1_spaghetti_detection_%s" % entity_description.key
-        self._attr_unique_id = "number.bambu_lab_p1_spaghetti_detection_%s" % entity_description.key
-        if self._attr_native_value is None:
-            self._attr_native_value = 0
+        self.entity_id = f"number.bambu_lab_p1_spaghetti_detection_{entity_description.key}"
+        self._attr_unique_id = f"number.bambu_lab_p1_spaghetti_detection_{entity_description.key}"
+        self._attr_native_value = 0
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value of the number entity."""
         self._attr_native_value = value
         self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": DEVICE_NAME,
+            "manufacturer": DEVICE_MANUFACTURER,
+            "model": DEVICE_MODEL,
+            "entry_type": DEVICE_ENTRY_TYPE,
+        }


### PR DESCRIPTION
small pet peeve of mine is not having devices grouping entities created by integrations, so I adjusted the code to group them together.

added a const.py file to consolidate things, also makes it easier to change the device name is a more appropriate ones is desired. 